### PR TITLE
windows,install: simplify instructions

### DIFF
--- a/site/docs/install-windows.md
+++ b/site/docs/install-windows.md
@@ -7,78 +7,70 @@ title: Installing Bazel on Windows
 
 Supported Windows platforms:
 
-*   64 bit Windows 7 or higher, or equivalent Windows Server versions.
+*   64-bit Windows 7 or higher, or equivalent Windows Server versions.
 
-_Check
-<a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx">Microsoft's
-Operating System Version table</a> to see if your OS is supported._
+### Installation
 
-### 1. Install prerequisites (if not already installed)
+1.  Download and install [MSYS2](https://msys2.github.io/).
 
-*   Python 2.7 or later.
+2.  Download the [latest Bazel binary](https://github.com/bazelbuild/bazel/releases).
 
-    Use the Windows-native Python version. Do not use Python that comes with the
-    MSYS2 shell or that you installed in MSYS using Pacman because it doesn't
-    work with Bazel.
+    No installation required.
 
-*   [MSYS2 shell](https://msys2.github.io/).
+    Optional: rename the binary to `bazel.exe` and move it to a directory that's on your `PATH`.
 
-    You also need to set the `BAZEL_SH` environment variable to point to
-    `bash.exe`. For example in the Windows Command Prompt (`cmd.exe`):
+3.  Try Bazel.
 
-    ```
-    set BAZEL_SH=C:\tools\msys64\usr\bin\bash.exe
-    ```
+    *    Start PowerShell or the Command Prompt (`cmd.exe`).
 
-    **Note**: do not use quotes (") around the path like you would on Unixes.
-    Windows doesn't need them and it may confuse Bazel.
+    *    Go to the directory where you downloaded Bazel:
+         ```sh
+         cd c:\Users\myusername\Downloads
+         ```
 
-*   Several MSYS2 packages.
+    *    Run `bazel version`:
+         ```sh
+         bazel version
+         ```
+         Example output:
+         ```sh
+         Extracting Bazel installation...
+         .
+         Build label: 0.12.0
+         Build target: bazel-out/x64_windows-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
+         Build time: Tue Aug 4 02:44:15 +50246 (1523462006655)
+         Build timestamp: 1523462006655
+         Build timestamp as int: 1523462006655
+         ```
 
-    Run the following command in the MSYS2 shell to install them:
+#### Other ways to get Bazel
 
-    ```bash
-    pacman -Syuu git curl zip unzip
-    ```
-
-*   [Microsoft Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
-
-    This may already be installed on your system.
-
-### 2. Install Bazel on Windows using one of the following methods:
-
-*   [Download the binary (recommended)](#download-the-binary-recommended)
-*   [Install using Chocolatey](#install-using-chocolatey)
 *   [Compile Bazel from source](install-compile-source.html)
 
-#### Download the binary (recommended)
+*   Install using [Chocolatey](https://chocolatey.org)
 
-Go to Bazel's [GitHub releases page](https://github.com/bazelbuild/bazel/releases)
-and download the Windows binary<sup>1</sup>: `bazel-<version>-installer-windows-x86_64.sh`.
+    Install the latest Bazel and dependencies:
 
-For convenience, move the binary to a directory that's on your `%PATH%`. This
-way you can run Bazel by typing `bazel` in any directory, without typing out the
-full path. That said, you may put the binary anywhere on your filesystem.
+    ```sh
+    choco install bazel
+    ```
 
-After you download the binary, you'll need additional
-software and some setup in your environment to run Bazel. For details, see the
-[Windows requirements](windows.html).
+    See [Chocolatey package maintenance guide](https://bazel.build/windows-chocolatey-maintenance.html) for more
+information.
 
-_<sup>1</sup>Note that Bazel includes an embedded JDK 8, which can be used even if a JDK is already installed. bazel-<version>-without-jdk-installer-windows-x86_64.sh is a version of the installer without embedded JDK 8. Only use this installer if you already have JDK 8 installed._
+#### Troubleshooting
 
-#### Install using Chocolatey
+*   Bazel won't start.
 
-You can install the Bazel package using the [Chocolatey](https://chocolatey.org)
-package manager:
+    -   **Incompatible Windows version**.
+    
+        Check the <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx">version table</a>. Bazel requires 64-bit Windows 7 or higher, or equivalent Windows Server versions. 32-bit Windows is not supported.
 
-```sh
-choco install bazel
-```
+    -   **"The application was unable to start correctly (0xc000007b)." error**
+    
+        Install the [Microsoft Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145).
+        
+    -   **MSVCP140.DLL is missing** or **VCRUNTIME140.DLL is missing**
+    
+        Install the [Microsoft Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145).
 
-This command will install the latest available version of Bazel and most of
-its dependencies, such as the MSYS2 shell. This will not install Visual C++
-though.
-
-See [Chocolatey installation and package maintenance
-guide](https://bazel.build/windows-chocolatey-maintenance.html) for more
-information about the Chocolatey package.


### PR DESCRIPTION
Simplify the Windows install instructions.

Notably:
- Python and the "several MSYS package" aren't required. (You need them to build Bazel itself.) Removed.
- Add a troubleshooting section.
- Remove all info about the JDK. Bazel comes with an embedded JDK.
- Remove info about BAZEL_SH. Bazel automatically detects where MSYS is installed.

See https://github.com/bazelbuild/bazel/issues/4784